### PR TITLE
Parse kiln user token to get username

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ KC_FR_SERVERURL=https://server.domain/auth #authentication keycloak server (e.g.
 FORMREPO_GETFORMURL=http://formrepo/forms
 SIEBEL_ICM_API_HOST=https://siebelapihost/
 TRUSTED_USERNAME=exampleUsername #trusted username for request
+USERNAME_SERVERURL=https://server.domain/userInfo #unserInfo from Keycloak server

--- a/databindingsHandler.js
+++ b/databindingsHandler.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const { JSONPath } = require('jsonpath-plus');
 const { keycloakForSiebel } = require("./keycloak.js");
 const axios = require("axios");
+const { getUsername } = require('./usernameHandler.js');
 
 async function populateDatabindings(formJson, params) {
   //start code here
@@ -95,6 +96,7 @@ function bindDataToFields(formJson, fetchedData) {
 async function readJsonFormApi(datasource, pathParams) {
   console.log("readJsonFormApi>>pathParams", pathParams);
   const { name, type, host, endpoint, params, body } = datasource;
+  const username = await getUsername(pathParams["token"]);
   //const url = `${endpoint}`;
   const url = buildUrlWithParams(host, endpoint, pathParams);
   try {
@@ -103,7 +105,7 @@ async function readJsonFormApi(datasource, pathParams) {
       await keycloakForSiebel.grantManager.obtainFromClientCredentials();
     const headers = {
       Authorization: `Bearer ${grant.access_token.token}`,
-      "X-ICM-TrustedUsername": process.env.TRUSTED_USERNAME,
+      "X-ICM-TrustedUsername": username,
     }
     if (type.toUpperCase() === 'GET') {
 

--- a/routes.js
+++ b/routes.js
@@ -4,6 +4,7 @@ const xmlparser = require("express-xml-bodyparser");
 const { keycloakForSiebel, keycloakForFormRepo } = require("./keycloak.js");
 const generateTemplate = require("./generateHandler");
 const { saveICMdata, loadICMdata, clearICMLockedFlag } = require("./saveICMdataHandler");
+const { getUsername } = require("./usernameHandler.js");
 
 const getFormsFromFormTemplate = require("./formRepoHandler");
 const router = express.Router();
@@ -33,11 +34,12 @@ router.get("/api*", async (req, res) => {
     const destinationPath = RegExp("api/(.*)").exec(req.path)[1];
     let endpointUrl = `${ENDPOINT_URL}${destinationPath}`;
     endpointUrl += "?ViewMode=Catalog&workspace=dev_sadmin_bz";
+    const username = await getUsername(req.headers["token"]);
 
     const newResp = await axios.get(endpointUrl, {
       headers: {
         Authorization: `Bearer ${grant.access_token.token}`,
-        "X-ICM-TrustedUsername": process.env.TRUSTED_USERNAME,
+        "X-ICM-TrustedUsername": username,
       },
     });
 

--- a/saveICMdataHandler.js
+++ b/saveICMdataHandler.js
@@ -3,6 +3,7 @@ const axios = require("axios");
 const databindingsHandler = require("./databindingsHandler.js");
 const buildUrlWithParams = databindingsHandler.buildUrlWithParams;
 const xml2js = require("xml2js");
+const { getUsername } = require("./usernameHandler.js");
 
 // utility function to fetch Attachment status (In Progress, Open...)
 //  and Locked By User field  
@@ -48,6 +49,7 @@ async function saveICMdata(req, res) {
     const params = req.body;
     const attachment_id = params["attachmentId"];
     console.log("attachment_id>>", attachment_id);
+    const username = await getUsername(params["token"]);
     if (!attachment_id) {
         return res
             .status(400)
@@ -77,7 +79,7 @@ async function saveICMdata(req, res) {
             await keycloakForSiebel.grantManager.obtainFromClientCredentials();
         const headers = {
             Authorization: `Bearer ${grant.access_token.token}`,
-            "X-ICM-TrustedUsername": process.env.TRUSTED_USERNAME,
+            "X-ICM-TrustedUsername": username,
         }
         const params = {
             viewMode: "Catalog"
@@ -101,6 +103,7 @@ async function loadICMdata(req, res) {
     const params = req.body;
     const attachment_id = params["attachmentId"];
     const office_name = params["OfficeName"];
+    const username = await getUsername(params["token"]);
     console.log("attachment_id>>", attachment_id);
     if (!attachment_id) {
         return res
@@ -122,7 +125,7 @@ async function loadICMdata(req, res) {
             await keycloakForSiebel.grantManager.obtainFromClientCredentials();
         const headers = {
             Authorization: `Bearer ${grant.access_token.token}`,
-            "X-ICM-TrustedUsername": process.env.TRUSTED_USERNAME,
+            "X-ICM-TrustedUsername": username,
         }
         const params = {
             viewMode: "Catalog",
@@ -149,6 +152,7 @@ async function loadICMdata(req, res) {
 async function clearICMLockedFlag(req, res) {
     const params = req.body;
     const attachment_id = params["attachmentId"];
+    const username = await getUsername(params["token"]);
     if (!attachment_id) {
         return res
             .status(400)
@@ -188,7 +192,7 @@ async function clearICMLockedFlag(req, res) {
             await keycloakForSiebel.grantManager.obtainFromClientCredentials();
         const headers = {
             Authorization: `Bearer ${grant.access_token.token}`,
-            "X-ICM-TrustedUsername": process.env.TRUSTED_USERNAME,
+            "X-ICM-TrustedUsername": username,
 
         }
         const params = {

--- a/usernameHandler.js
+++ b/usernameHandler.js
@@ -1,0 +1,31 @@
+const axios = require("axios");
+
+async function getUsername(userToken) {
+    if (!userToken) {
+        console.warn("No user token provided. Using default.");
+        return process.env.TRUSTED_USERNAME;
+    }
+
+    try {
+        const userInfoResponse = await axios.get(process.env.USERNAME_SERVERURL,
+            {
+                headers: {
+                    Authorization: `Bearer ${userToken}`,
+                },
+            }
+        );
+
+        if (userInfoResponse.data && userInfoResponse.data.idir_username) {
+            return userInfoResponse.data.idir_username;
+        } else {
+            console.warn("Username not found.");
+        }
+    } catch (error) {
+        console.error("Error fetching username from Keycloak:", error);
+    }
+
+    return process.env.TRUSTED_USERNAME;
+}
+
+module.exports.getUsername = getUsername;
+


### PR DESCRIPTION
Uses the username token provided from kiln to fetch the username for API requests. Note, for the API forwarding service, the token would need to be provided in the header.