### PR TITLE
Configure Form Instance endpoint name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,10 @@ KC_FR_CLIENTSECRET=yourclientsecret #your shared secret for keycloak client
 KC_FR_REALM=standard
 KC_FR_SERVERURL=https://server.domain/auth #authentication keycloak server (e.g. https://server.domain/auth)
 FORMREPO_GETFORMURL=http://formrepo/forms
-SIEBEL_ICM_API_HOST=https://siebelapihost/
+SIEBEL_ICM_API_HOST=https://siebelapihost/v1.0/data/
+SIEBEL_ICM_API_FORMS_ENDPOINT=/ICM Business Object/ICM Primary Business Component/  #ICM Endpoint for Saving and Retrieveing form data and metadata
+SIEBEL_ICM_API_WORKSPACE=workspace_name #Optional. Name of the workspace where the above endpoint is created.
+
 USERNAME_SERVERURL=https://server.domain/userInfo #unserInfo from Keycloak server
 SIEBEL_ICM_API_EMPLOYEE_URL=https://server.domain #Employee info domain
 

--- a/databindingsHandler.js
+++ b/databindingsHandler.js
@@ -152,7 +152,8 @@ async function readJsonFormApi(datasource, pathParams) {
 
 function buildUrlWithParams(host, endpoint, pathVariables) {
   const hostFromEnv = getHost(host);
-  let url = `${hostFromEnv}${endpoint}`;
+  const endpointFromEnv = getEndpoint(endpoint);
+  let url = `${hostFromEnv}${endpointFromEnv}`;
   // Replace any placeholder variables like @@attachmentId
   Object.keys(pathVariables).forEach(key => {
     const placeholder = `@@${key}`;
@@ -167,6 +168,10 @@ function getHost(host) {
   return process.env[host] || host;
 }
 
+function getEndpoint(endpoint){
+  // Use endpoint from environment variable if available, otherwise fall back to JSON
+  return process.env[endpoint] || endpoint;
+}
 function buildBodyWithParams(bodyFromJson, pathVariables) {
 
   let bodyString = JSON.stringify(bodyFromJson);

--- a/routes.js
+++ b/routes.js
@@ -31,7 +31,7 @@ router.get("/status", (req, res) => {
   res.send({ status: "running" });
 });
 
-// API forwarding route
+/*/ API forwarding route
 router.get("/api*", async (req, res) => {
   try {
     const grant =
@@ -57,7 +57,7 @@ router.get("/api*", async (req, res) => {
     console.error("API error: " + err.message);
     res.status(500).send({ error: err.message });
   }
-});
+});*/
 
 // XML form post route
 router.post("/form1", xmlparser(), async (req, res) => {

--- a/saveICMdataHandler.js
+++ b/saveICMdataHandler.js
@@ -5,6 +5,7 @@ const buildUrlWithParams = databindingsHandler.buildUrlWithParams;
 const xml2js = require("xml2js");
 const { getUsername } = require("./usernameHandler.js");
 
+const SIEBEL_ICM_API_FORMS_ENDPOINT = process.env.SIEBEL_ICM_API_FORMS_ENDPOINT;
 // utility function to fetch Attachment status (In Progress, Open...)
 //  and Locked By User field  
 async function getICMAttachmentStatus(attachment_id, username) {
@@ -15,7 +16,8 @@ async function getICMAttachmentStatus(attachment_id, username) {
     if (!attachment_id || attachment_id == "") {
         return return_data;
     }
-    let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
+    //let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
+    let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', SIEBEL_ICM_API_FORMS_ENDPOINT + attachment_id + '/', '');
     try {
         let response;
         const grant =
@@ -77,7 +79,8 @@ async function saveICMdata(req, res) {
     let builder = new xml2js.Builder();
     saveJson["XML Hierarchy"] = builder.buildObject(saveData);
 
-    let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
+    //let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
+    let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', SIEBEL_ICM_API_FORMS_ENDPOINT + attachment_id + '/', '');
     try {
         let response;
         const grant =
@@ -128,7 +131,7 @@ async function loadICMdata(req, res) {
         return null;
     }
     //let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT FormFoundry Upsert/DT Form Instance Orbeon Revise/'+attachment_id+'/','');
-    let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
+    let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', SIEBEL_ICM_API_FORMS_ENDPOINT + attachment_id + '/', '');
     try {
         let response;
         const grant =
@@ -201,7 +204,8 @@ async function clearICMLockedFlag(req, res) {
         saveJson["Locked By Id"] = "";
         saveJson["Token"] = "";
 
-        let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
+        //let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
+        let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', SIEBEL_ICM_API_FORMS_ENDPOINT + attachment_id + '/', '');
         let response;
         const grant =
             await keycloakForSiebel.grantManager.obtainFromClientCredentials();


### PR DESCRIPTION
Instead of hardcoded DT Form Instance/DT Form Instance endpoint, configure the name in .env . Use it to build ICM API URLs.

Remove obsolete /api API forwarding route.