### PR TITLE
Decode username locally instead of api call

### DIFF
--- a/usernameHandler.js
+++ b/usernameHandler.js
@@ -37,14 +37,11 @@ async function getUsername(userToken) {
     }
 
     try {
+        const tokens = JSON.parse(Buffer.from(userToken.split('.')[1], 'base64').toString());
+        
+        if (tokens && tokens.idir_username) {
 
-        const userInfoResponse = await axios.get(process.env.USERNAME_SERVERURL, {
-            headers: {
-                Authorization: `Bearer ${userToken}`,
-            },
-        });
-        if (userInfoResponse.data && userInfoResponse.data.idir_username) {
-            const username = userInfoResponse.data.idir_username;
+            const username = tokens.idir_username;
 
             try {
                 const isValid = await isUsernameValid(username);


### PR DESCRIPTION
Removed the API call to decode the jwt username. Instead, do it programmatically on the server.