### PR TITLE
Support single objects and allows parameters to reference previous API calls

### DIFF
--- a/databindingsHandler.js
+++ b/databindingsHandler.js
@@ -264,7 +264,6 @@ function updateParams(params, pathParams = {}, allFetchedData = {}) {
           if (Array.isArray(valueArr) && valueArr.length > 0 && valueArr[0] != null) {
             const raw = valueArr[0];
             if (typeof raw === 'object' && raw !== null) {
-              // if it's an object, prefer raw.Id or raw.id (or fallback to JSON.stringify)
               safeValue = raw.Id ?? raw.id ?? JSON.stringify(raw);
             } else {
               safeValue = raw;


### PR DESCRIPTION
## What changes did you make?

Allow databindings to be both arrays and single objects. Also support parameters to reference fields in previous API calls. @@placeholders from pathParams and !!.[Source]=jsonpath in the string for reference to previous API calls.

## Why did you make these changes?

To support both kind of API response and allow databinding's to reference other API calls.

## What alternatives did you consider?

None.

### Checklist

- [X] **I have assigned at least one reviewer**
- [X] **My code meets the style guide**
- [X] **My code has adequate test coverage (if applicable)**
