### PR TITLE
ADO-3158 xml quick fix

### DIFF
--- a/saveICMdataHandler.js
+++ b/saveICMdataHandler.js
@@ -155,7 +155,7 @@ async function saveICMdata(req, res) {
           truncatedKeysSaveData[newKey] = saveData[oldKey]; //Data is added to new JSON with the truncated key
         }
     }
-    let builder = new xml2js.Builder();
+    let builder = new xml2js.Builder({xmldec: { version: '1.0' }});
     saveJson["XML Hierarchy"] = builder.buildObject(truncatedKeysSaveData); 
     //let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
     let url = buildUrlWithParams(params["apiHost"], params["saveEndpoint"] + attachment_id + '/', params);


### PR DESCRIPTION
## What changes did you make?

Included xmldec to the xml2js builder.
let builder = new xml2js.Builder({xmldec: { version: '1.0' }});

## Why did you make these changes?

This was added so that the xml builder no longer generated default start tag for xml definitions. Adding this change means it will only show version and will not show standalone or encoding.
The the <?xml tag at the beginning of the following response previews for the changes. (Ignore the commented out code in the image. It was changed for testing purposes and then put back after confirmation of change.)

Original Output
<img width="1953" height="736" alt="Screenshot 2025-08-19 094451" src="https://github.com/user-attachments/assets/8ef6e123-a31a-43d6-8170-be256abf5b51" />

New Output
<img width="1736" height="353" alt="Screenshot 2025-08-19 094913" src="https://github.com/user-attachments/assets/5041f41c-2349-4962-823a-697de62d575a" />

## What alternatives did you consider?

None as this was the quick fix asked and tested.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
