### PR TITLE
(ADO-3242) Date format YYYY-MM-DD into MM/DD/YYYY for save ICM data

### DIFF
--- a/dateConverter.js
+++ b/dateConverter.js
@@ -1,0 +1,21 @@
+/* Function changes string from YYYY-MM-DD date format to MM/DD/YYYY
+ * @param (String) originalDate
+ */
+function toICMFormat(originalDate) {
+    if (originalDate === '' || originalDate === null) { // If the date is empty, no need to proceed
+        return originalDate;
+    }
+    let newDate = ''; // The new date to be created
+    try {
+    const yearMonthDay = originalDate.split("-"); // Split into array [Year, Month, Day]
+    newDate = yearMonthDay[1] + "/" + yearMonthDay[2] + "/" + yearMonthDay[0] // Turn into "Month/Day/Year"
+    } catch (e) {
+        console.log("Something went wrong with configuring the date!");
+        console.error(e);
+        return "-1";
+    }
+    return newDate;
+}
+
+// Export the function so it can be used in other files
+module.exports = { toICMFormat };


### PR DESCRIPTION
Commit: create a date converter and change date format to ICM required format for XML conversion

## What changes did you make?

Added a file called dateConverter.js that contains a function which converts a string in date format YYYY-MM-DD to a string in date format MM/DD/YYYY.

Updated saveICMdataHandler.js to find all the fields using type: date, and then updated the date format to the above ICM required MM/DD/YYYY with the function.

## Why did you make these changes?

As per https://dev.azure.com/BC-SDPR/Forms%20Modernization/_workitems/edit/3232, ICM requires date fields have their format be MM/DD/YYYY. The form data uses YYYY-MM-DD, which is currently not acceptable for ICM. Updating the dates to use MM/DD/YYYY when translated to XML version should fix this.

Child date field ids do not include their parent UUIDs while comparing the found field type, which is why there's a substring check: `dateItemsId.includes(oldChildKey.substring(stringLength+3, childStringLength))`

## What alternatives did you consider?

I considered using a pattern match to update date fields to new format, however that ran the risk up updating non-date field types. By finding the date field ids first and then applying format changes during the UUID change, this meant there was no additional looping happening to overwrite the fields and no problem matching UUIDs with the date field ids found. 

There is an error handling for the function when a date input does not met requirements (i.e. cannot be separated into Year, Month, Day for re-formatting). This sets the return values as -1 because there is a chance of date fields being null within the json/form.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
