### PR TITLE
ADO-3265 JSON/XML configuration and start to form exception dictionary

### DIFF
--- a/dictionary/dictionaryUtils.js
+++ b/dictionary/dictionaryUtils.js
@@ -1,0 +1,33 @@
+/* Checks if a dictionary key exists
+ * @param dictionary : the dictionary to search through
+ * @param key : the key in the dictionary
+ * @param property : the key's property
+ */
+function keyExists (dictionary, key) {
+    if (dictionary[key]) return true;
+    else return false;
+};
+
+/* Checks if a dictionary key has a property value 
+ * @param dictionary : the dictionary to search through
+ * @param key : the key in the dictionary
+ * @param property : the key's property
+ */
+function propertyExists (dictionary, key, property) {
+    if (dictionary[key] && dictionary[key][property]) return true;
+    else return false;
+};
+
+/* Checks if a property value is not empty
+ * @param dictionary : the dictionary to search through
+ * @param key : the key in the dictionary
+ * @param property : the key's property
+ */
+function propertyNotEmpty (dictionary, key, property) {
+    const propertyType = typeof dictionary[key][property];
+    if (propertyType === "string" && dictionary[key][property] != "") return true;
+    if (propertyType === "object" && dictionary[key][property] != []) return true;
+    else return false;
+};
+
+module.exports = { keyExists, propertyExists, propertyNotEmpty };

--- a/dictionary/jsonXmlConversion.js
+++ b/dictionary/jsonXmlConversion.js
@@ -1,0 +1,17 @@
+/* List of forms that do not convert directly from JSON to XML
+ * Keys are the form_definition.form_id
+ * Property: rootName : a string that will replace "root" from the XML
+ * Property: subRoots : an array of strings. These will be between root and JSON data. The first value in the array will be highest (after root) while the last will be lowest (before JSON)
+ * Property: omitFields : an array of strings. These are the UUIDs of fields that must be omitted before XML creation. (TO BE DONE in saveICMdataHandler.js)
+ * Property: version : a string that will check if the exception list should include the version of the form submitted.
+ */
+const formExceptions = {
+     "HR3689E": { 
+        "rootName": "ListOfDtFormInstanceLW", 
+        "subRoots": ["FormInstance"],
+        "omitFields": [],
+        "version": "2",
+    }
+};
+
+module.exports = { formExceptions };

--- a/saveICMdataHandler.js
+++ b/saveICMdataHandler.js
@@ -8,6 +8,8 @@ const { getErrorMessage } = require("./errorHandling/errorHandler.js");
 const { isJsonStringValid } = require("./validate.js");
 const appCfg = require('./appConfig.js');
 const { toICMFormat } = require("./dateConverter.js");
+const { formExceptions } = require("./dictionary/jsonXmlConversion.js");
+const { propertyExists, propertyNotEmpty, keyExists } = require("./dictionary/dictionaryUtils.js");
 
 const SIEBEL_ICM_API_FORMS_ENDPOINT = process.env.SIEBEL_ICM_API_FORMS_ENDPOINT;
 // utility function to fetch Attachment status (In Progress, Open...)
@@ -193,8 +195,40 @@ async function saveICMdata(req, res) {
             }
         }
     }
-    let builder = new xml2js.Builder({xmldec: { version: '1.0' }});
-    saveJson["XML Hierarchy"] = builder.buildObject(truncatedKeysSaveData); 
+    let builder; // This will be for building the XML
+    const formId = JSON.parse(savedFormParam)["form_definition"]["form_id"]; // Get the form ID
+    const formVersion = JSON.parse(savedFormParam)["form_definition"]["version"]; // Get the form version
+    const dictionary = formExceptions;
+    if (keyExists(dictionary, formId) && dictionary[formId].version === formVersion) { // If any forms with the correct version have been listed as exceptions, then proceed with their form exceptions
+        // If the root needs a differernt name, apply it here. Otherwise use the default "root"
+        if (propertyExists(dictionary, formId, "rootName") && propertyNotEmpty(dictionary, formId, "rootName")) {
+            builder = new xml2js.Builder({xmldec: { version: '1.0' }, rootName: dictionary[formId]["rootName"]});
+        } else {
+            builder = new xml2js.Builder({xmldec: { version: '1.0' }});
+        }
+
+        let wrapperJson = truncatedKeysSaveData;
+        // If subRoots exist, wrap the sub-roots around the JSON where the last array object will be closest to JSON and first array object will be closest to root/rootName
+        if (propertyExists(dictionary, formId, "subRoots") && propertyNotEmpty(dictionary, formId, "subRoots")) {
+            wrapperJson = {};
+            let tempJson = {};
+            const subRootLength = dictionary[formId]["subRoots"].length;
+            for (i = subRootLength; i > 0; i= i -1) {
+                if (i === subRootLength) {
+                    tempJson[dictionary[formId]["subRoots"][i-1]] = truncatedKeysSaveData;
+                } else {
+                    wrapperJson[dictionary[formId]["subRoots"][i-1]] = tempJson;
+                    tempJson = wrapperJson;
+                    wrapperJson = {};
+                }
+            }
+            wrapperJson = tempJson;
+        }
+        saveJson["XML Hierarchy"] = builder.buildObject(wrapperJson);
+    } else {
+        builder = new xml2js.Builder({xmldec: { version: '1.0' }});
+        saveJson["XML Hierarchy"] = builder.buildObject(truncatedKeysSaveData);
+    } 
     //let url = buildUrlWithParams('SIEBEL_ICM_API_HOST', 'fwd/v1.0/data/DT Form Instance Thin/DT Form Instance Thin/' + attachment_id + '/', '');
     let url = buildUrlWithParams(params["apiHost"], params["saveEndpoint"] + attachment_id + '/', params);
     try {


### PR DESCRIPTION
## What changes did you make?

Created two files:
- One to contain the dictionary of forms who require exceptions to their XML creation.
- One to contain functions for viewing and confirming dictionary values.

Updates to saveICMdataHandler.js. 
- Calls the dictionary of form exceptions to confirm if form ID and VERSION match the incoming form. 
- If exception form is being processed, then it checks if changes are required for the root name and sub-root-names. Sub-roots wrap around the JSON such that:
["Blue", "Yellow", "Red"]
will look like:
{ "Blue": {
   "Yellow": {
      "Red": {
...the JSON
      }
   }
}

## Why did you make these changes?

Dictionary file keeps track of the forms who's XML creations are exceptions to the norm and will throw an error if they do not meet a certain standard.
The functions are kept in a separate file in case more dictionaries are required in the future.
Sub-roots are the way they are to make it as close to a hierarchy as possible with index = 0 at the top (after root) and the last index at the bottom (before JSON body).

## What alternatives did you consider?

Coming up with multiple use cases and if-else statements to try and determine forms would require exceptions. Unfortunately there are no good ways to determine which forms require exceptions, so a hardcoded list is required.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
