### PR TITLE
For checkbox, yes/no answers in bindings are transformed to true/false

### DIFF
--- a/databindingsHandler.js
+++ b/databindingsHandler.js
@@ -266,6 +266,16 @@ function transformValueToBindIfNeeded(field, valueToBind) {
       const transformedValue = format(parsedDate, "yyyy-MM-dd");
       return transformedValue;
     }
+    if (field && field.type == "checkbox" && valueToBind){
+      if (valueToBind == "Yes" || valueToBind=="yes")
+      {
+        return (true);
+      }
+      if (valueToBind == "No"|| valueToBind=="no")
+      {
+        return (false);
+      }
+    }
   } catch (error) {
     console.error('Error processing date value:', error);
   }


### PR DESCRIPTION
## What changes did you make?

Add a check for checkbox type field on databinding step to transform Yes/No (or yes/no) type answers to true/false

## Why did you make these changes?

ICM Portals set the checkboxes to Yes/No. Currently FormFoundry uses true/false always.

## What alternatives did you consider?

Create a preprocess of some kind inside the ICM Json Clob processing service to map incoming values to form values. 
### Checklist

- [x ] **I have assigned at least one reviewer**
- [x ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
