### PR TITLE
Ado 3265 wrapping tags

### DIFF
--- a/dictionary/dictionaryUtils.js
+++ b/dictionary/dictionaryUtils.js
@@ -1,38 +1,42 @@
-/* Checks if a dictionary key exists
+/** Checks if a dictionary key exists
  * @param dictionary : the dictionary to search through
  * @param key : the key in the dictionary
  * @param property : the key's property
+ * @return boolean true/false 
  */
 function keyExists (dictionary, key) {
     if (dictionary[key]) return true;
     else return false;
 };
 
-/* Checks if a dictionary key has a property value 
+/** Checks if a dictionary key has a property value 
  * @param dictionary : the dictionary to search through
  * @param key : the key in the dictionary
  * @param property : the key's property
+ * @return boolean true/false 
  */
 function propertyExists (dictionary, key, property) {
     if (dictionary[key] && dictionary[key][property]) return true;
     else return false;
 };
 
-/* Checks if a dictionary key's property's key exists
+/** Checks if a dictionary key's property's key exists
  * @param dictionary : the dictionary to search through
  * @param key : the key in the dictionary
  * @param property : the key's property
  * @param propertyKey : the property's key
+ * @return boolean true/false 
  */
 function propertyKeyExists (dictionary, key, property, propertyKey) {
     if (dictionary[key] && dictionary[key][property] && dictionary[key][property][propertyKey]) return true;
     else return false;
 };
 
-/* Checks if a property value is not empty
+/** Checks if a property value is not empty
  * @param dictionary : the dictionary to search through
  * @param key : the key in the dictionary
  * @param property : the key's property
+ * @return boolean true/false 
  */
 function propertyNotEmpty (dictionary, key, property) {
     const propertyType = typeof dictionary[key][property];
@@ -41,16 +45,17 @@ function propertyNotEmpty (dictionary, key, property) {
     else return false;
 };
 
-/* Checks if a property value is not empty
+/** Checks if a property value is not empty
  * @param dictionary : the dictionary to search through
  * @param key : the key in the dictionary
  * @param property : the key's property
  * @param propertyKey : the property's key
+ * @return boolean true/false 
  */
 function propertyKeyNotEmpty (dictionary, key, property, propertyKey) {
     const propertyType = typeof dictionary[key][property];
     if (propertyType === "string" && dictionary[key][property] != "") return true;
-    else if (propertyType === "object" && dictionary[key][property][propertyKey] != [] && dictionary[key][property][propertyKey] != {}) return true;
+    else if (propertyType === "object" && dictionary[key][property][propertyKey] != [] && dictionary[key][property][propertyKey].length != 0 && dictionary[key][property][propertyKey] != {}) return true;
     else return false;
 };
 

--- a/dictionary/dictionaryUtils.js
+++ b/dictionary/dictionaryUtils.js
@@ -37,7 +37,7 @@ function propertyKeyExists (dictionary, key, property, propertyKey) {
 function propertyNotEmpty (dictionary, key, property) {
     const propertyType = typeof dictionary[key][property];
     if (propertyType === "string" && dictionary[key][property] != "") return true;
-    else if (propertyType === "object" && dictionary[key][property] != [] && dictionary[key][property] != {}) return true;
+    else if (propertyType === "object" && dictionary[key][property].length != 0 && dictionary[key][property] != {}) return true;
     else return false;
 };
 

--- a/dictionary/jsonXmlConversion.js
+++ b/dictionary/jsonXmlConversion.js
@@ -2,13 +2,61 @@
  * Keys are the form_definition.form_id
  * Property: rootName : a string that will replace "root" from the XML
  * Property: subRoots : an array of strings. These will be between root and JSON data. The first value in the array will be highest (after root) while the last will be lowest (before JSON)
+ * Property: wrapperTags : an array of objects. If not empty, then should include object { [the wrapper Tag name] : { wrapFields: [], wrapperTags: []} } where the second wrapperTag repeats the full object if children are needed.
+ * Property: allowBooleanCheckbox : if a field is in this array, skip conversion step
  * Property: omitFields : an array of strings. These are the UUIDs of fields that must be omitted before XML creation. (TO BE DONE in saveICMdataHandler.js)
- * Property: version : a string that will check if the exception list should include the version of the form submitted.
+ * Property: version : a string that will check if the exception list should include the version of the form submitted. All values in version should overwrite the default form properties.
  */
 const formExceptions = {
-     "HR3689E": { 
+    "HR3689E": { 
         "rootName": "ListOfDtFormInstanceLW", 
         "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowBooleanCheckbox": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "CF0925": {
+        "rootName": "", 
+        "subRoots": [],
+        "wrapperTags": [
+            {
+                "ParentGuardian": {
+                    "wrapFields": [
+                        "last-name-91433118-4a0c-47fe-80d8-2676f83a2022",
+                        "first-name-5dd5f94c-be98-4dd1-a442-3903c6330391",
+                        "middle-names-690ef4b4-bf83-487e-8ef2-fd39f09fb545",
+                        "address-parent-9dcf849c-b28b-4faa-afe3-8603af7c98fa",
+                        "unit-fbbdce5c-a970-4d8f-98f5-d3a6e8af6005",
+                        "address-1-a81293da-3d95-42cf-b6fa-ec15fac39ed1",
+                        "address-2-3f5515c8-8d91-424f-8302-0e7fea6599bf",
+                        "city-80cbf0f7-fa28-47f0-a4e4-94793e8a12fb",
+                        "province-835a46e3-4a7c-4496-a196-8e93172092ed",
+                        "postal-code-29edf972-2b5c-421d-a1ab-d97aa4005911",
+                        "primary-phone-number-type-a7eba596-6474-4a01-93e5-6cd49c8ef4cc",
+                        "primary-phone-number-f29b9ffd-9e7c-4f20-8bc3-57b333d88a0e",
+                        "secondary-phone-number-type-fc15a5f0-bfcd-4fe8-8836-833fc2573525",
+                        "secondary-phone-number-135375c3-f0bc-4b3a-aea2-b98995676ebc",
+                    ], 
+                    "wrapperTags" : []
+                },
+            },
+            {
+                "Child" : {
+                    "wrapFields" : [],
+                    "wrapperTags" : []
+                }
+            }
+        ],
+        "allowBooleanCheckbox": [],
+        "omitFields": [],
         "versions" : {
             "1" :{
                 "omitFields": []
@@ -17,7 +65,7 @@ const formExceptions = {
                 "omitFields": []
             }
         }
-    }
+    } 
 };
 
 module.exports = { formExceptions };

--- a/dictionary/jsonXmlConversion.js
+++ b/dictionary/jsonXmlConversion.js
@@ -2,7 +2,7 @@
  * Keys are the form_definition.form_id
  * Property: rootName : a string that will replace "root" from the XML
  * Property: subRoots : an array of strings. These will be between root and JSON data. The first value in the array will be highest (after root) while the last will be lowest (before JSON)
- * Property: wrapperTags : an array of objects. If not empty, then should include object { [the wrapper Tag name] : { wrapFields: [], wrapperTags: []} } where the second wrapperTag repeats the full object if children are needed.
+ * Property: wrapperTags : an array of objects. If not empty, then should include object { [the wrapper Tag name] : { wrapFields: [] } }
  * Property: allowBooleanCheckbox : if a field is in this array, skip conversion step
  * Property: omitFields : an array of strings. These are the UUIDs of fields that must be omitted before XML creation. (TO BE DONE in saveICMdataHandler.js)
  * Property: version : a string that will check if the exception list should include the version of the form submitted. All values in version should overwrite the default form properties.
@@ -43,15 +43,18 @@ const formExceptions = {
                         "primary-phone-number-type-a7eba596-6474-4a01-93e5-6cd49c8ef4cc",
                         "primary-phone-number-f29b9ffd-9e7c-4f20-8bc3-57b333d88a0e",
                         "secondary-phone-number-type-fc15a5f0-bfcd-4fe8-8836-833fc2573525",
-                        "secondary-phone-number-135375c3-f0bc-4b3a-aea2-b98995676ebc",
+                        "secondary-phone-number-135375c3-f0bc-4b3a-aea2-b98995676ebc"
                     ], 
-                    "wrapperTags" : []
                 },
             },
             {
                 "Child" : {
-                    "wrapFields" : [],
-                    "wrapperTags" : []
+                    "wrapFields" : [
+                        "child-last-name-15a0adbf-a3bd-4bd1-be3f-bfb9a2b02f3e",
+                        "child-first-name-4a8302bb-6eca-46c8-ae50-efe37434ea8e",
+                        "child-middle-names-81cf1856-1541-4eed-85d8-1f376b727fd0",
+                        "child-dob-3d6f9a94-7c0f-4a06-89dc-872ee39fa818"
+                    ],
                 }
             }
         ],

--- a/saveICMdataHandler.js
+++ b/saveICMdataHandler.js
@@ -162,9 +162,6 @@ async function saveICMdata(req, res) {
     }
 
 
-    // TODO: The if-statement. The Else-statement at the very bottom is done. Consider making these checks a function.
-
-
     for(let oldKey in saveData) { //This begins trunicating the JSON keys for XML (UUID should be first 8 characters)
         const stringLength = oldKey.length;
         const newKey = oldKey.substring(0, stringLength-28);
@@ -189,9 +186,15 @@ async function saveICMdata(req, res) {
                 }
                 childrenArray.push(truncatedChildrenKeys);
             }
-            const wrapperKey = {} 
-            wrapperKey[newKey] = childrenArray;
-            truncatedKeysSaveData[`${newKey}-List`] = wrapperKey // Add a wrapper around the children/dependecies
+            if (toWrapIds[oldKey]) {
+                const wrapperKey = {};
+                wrapperKey[newKey] = childrenArray;
+                truncatedKeysSaveData[toWrapIds[oldKey]][`${newKey}-List`] = wrapperKey // Add a wrapper around the children/dependecies
+            } else {
+                const wrapperKey = {};
+                wrapperKey[newKey] = childrenArray;
+                truncatedKeysSaveData[`${newKey}-List`] = wrapperKey; // Add a wrapper around the children/dependecies
+            }
         } else {
             if (dateItemsId.includes(oldKey)) { // If data is in a date field, change date format from YYYY-MM-DD to MM/DD/YYYY
                 const newDateFormat = toICMFormat(saveData[oldKey]);


### PR DESCRIPTION
## What changes did you make?

- Fixed function descriptions for dictionary utils
- Fixed is empty checks in dictionary utils
- Added values to form dictionary for wrapping tags
- Added wrapper capability to saveICMdataHandler.js
- Moved majority of JSON readying for XML code to its own function for clearer readability 

## Why did you make these changes?

- Function descriptions are now visible when hovering over a function in another file.
- Empty checks need to be able to see if an array or object is empty.
- The wrapping tag includes the name of the tag to be the wrapper (the key) and a list of the UUIDs for the form that will be wrapped in it (the object/list of ids). Using this wrapper will solve the issue of UUIDs being required to group for certain wrappers/parent tags.
- The changes for configuring JSON values to meet standards when they transform to XML was getting very long. Moving it to its own function keeps it all in one place and allows the saveICMdata to be more readable.

## What alternatives did you consider?

I considered using a list of objects to contain wrapper name and wrapper UUIDs required in one object rather than having the name be the key. However, the current format is a lot easier to read in the dictionary and pair up full UUIDs to be wrapped when sorting through the configurations for JSON to XML changes.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
