### PR TITLE
Ado 3265 omit fields from xml

### DIFF
--- a/dictionary/jsonXmlConversion.js
+++ b/dictionary/jsonXmlConversion.js
@@ -2,9 +2,9 @@
  * Keys are the form_definition.form_id
  * Property: rootName : a string that will replace "root" from the XML
  * Property: subRoots : an array of strings. These will be between root and JSON data. The first value in the array will be highest (after root) while the last will be lowest (before JSON)
- * Property: wrapperTags : an array of objects. If not empty, then should include object { [the wrapper Tag name] : { wrapFields: [] } }
+ * Property: wrapperTags : an array of objects. If not empty, then should include object { [the wrapper Tag name] : { wrapFieldsName: indexOfDepth } }
  * Property: allowCheckboxWithNoChange : if a field is in this array, skip conversion step
- * Property: omitFields : an array of strings. These are the UUIDs of fields that must be omitted before XML creation. (TO BE DONE in saveICMdataHandler.js)
+ * Property: omitFields : an array of strings. These are the UUIDs of fields that must be omitted before XML creation. For child UUIDs, include only the values after "-i-" where i is the index of the list
  * Property: version : a string that will check if the exception list should include the version of the form submitted. All values in version should overwrite the default form properties.
  */
 const formExceptions = {

--- a/saveICMdataHandler.js
+++ b/saveICMdataHandler.js
@@ -551,19 +551,23 @@ function fixJSONValuesForXML (saveData, truncatedKeysSaveData, toWrapIds, dateIt
                     for (let oldChildKey in saveData[oldKey][i]) {
                         const childStringLength = oldChildKey.length;
                         const newChildKey = oldChildKey.substring(stringLength+3, childStringLength-28);
-                        if (dateItemsId.includes(oldChildKey.substring(stringLength+3, childStringLength))) { // If child data is in a date field, change date format from YYYY-MM-DD to MM/DD/YYYY
-                            const newDateFormat = toICMFormat(saveData[oldKey][i][oldChildKey]); 
-                            if (newDateFormat === "-1") {
-                                throw new Error("Invalid date. Was unable to convert to ICM format!");
+                        if (!omitFields.includes(oldChildKey.substring(stringLength+3, childStringLength))) {
+                            if (dateItemsId.includes(oldChildKey.substring(stringLength+3, childStringLength))) { // If child data is in a date field, change date format from YYYY-MM-DD to MM/DD/YYYY
+                                const newDateFormat = toICMFormat(saveData[oldKey][i][oldChildKey]); 
+                                if (newDateFormat === "-1") {
+                                    throw new Error("Invalid date. Was unable to convert to ICM format!");
+                                }
+                                truncatedChildrenKeys[newChildKey] = newDateFormat;
+                            } else if (checkboxItemsId.includes(oldChildKey.substring(stringLength+3, childStringLength)) && !noCheckboxChange.includes(oldChildKey.substring(stringLength+3, childStringLength))) { // If child data is in a checkbox field AND is not listed for ommission, change from true/false/undefined to Yes/No/""
+                                truncatedChildrenKeys[newChildKey] = convertCheckboxFormatToICM(saveData[oldKey][i][oldChildKey]);
+                            } else {
+                                truncatedChildrenKeys[newChildKey] = saveData[oldKey][i][oldChildKey];
                             }
-                            truncatedChildrenKeys[newChildKey] = newDateFormat;
-                        } else if (checkboxItemsId.includes(oldChildKey.substring(stringLength+3, childStringLength)) && !noCheckboxChange.includes(oldChildKey.substring(stringLength+3, childStringLength))) { // If child data is in a checkbox field AND is not listed for ommission, change from true/false/undefined to Yes/No/""
-                            truncatedChildrenKeys[newChildKey] = convertCheckboxFormatToICM(saveData[oldKey][i][oldChildKey]);
-                        } else {
-                            truncatedChildrenKeys[newChildKey] = saveData[oldKey][i][oldChildKey];
                         }
                     }
-                    childrenArray.push(truncatedChildrenKeys);
+                    if (Object.keys(truncatedChildrenKeys).length != 0) {
+                        childrenArray.push(truncatedChildrenKeys);
+                    }
                 }
                 if (toWrapIds[oldKey]) {
                     if (!truncatedKeysSaveData[toWrapIds[oldKey].tags[0]]) { //Initalize wrapper if top level doesn't exist


### PR DESCRIPTION
## What changes did you make?

Wrapped JSON -> XML fixes code in a check that only adds value to final JSON -> XML if the field is not in the dictionary's omit fields. For forms not in dictionary, the omit list should be empty so everything passes. 

This omit works for normal (highest level and their children) and list-children values in JSON.

## Why did you make these changes?

Some forms do not require every JSON property to be added to XML. Using the dictionary, this allows us to omit fields that would normally otherwise appear in the XML format.

## What alternatives did you consider?

Moving the omit checks to the "push" areas of the code. This would stop the omit field from being added, however that would mean "fixes" were applied for no reason. By moving the omit check around the bulk of the code, this stops it from proceeding with the "fixes" and stops it from adding the field to the JSON -> XML

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
