### PR TITLE
ADO-3215 Kiln v1 and v2 save and generate updates

### DIFF
--- a/saveICMdataHandler.js
+++ b/saveICMdataHandler.js
@@ -128,14 +128,8 @@ async function saveICMdata(req, res) {
         .status(400)
         .send({ error: getErrorMessage("FORM_NOT_VALID") });
     }
-    /**
-     * Apply Kiln Version
-     * Kiln V1 uses data: { items: []}
-     * Kiln V2 uses dataSources []
-     */
-    const kilnVersion = Object.keys(JSON.parse(savedFormParam)["data"]).includes("items") ? 1 : 2; 
-
-    const valid = isJsonStringValid(savedFormParam, kilnVersion);
+ 
+    const valid = isJsonStringValid(savedFormParam);
     if (!valid) {
         console.log('JSON is  not valid ');
         return res
@@ -151,6 +145,14 @@ async function saveICMdata(req, res) {
     saveJson["DocFileExt"] = "json";
     saveJson["Doc Attachment Id"] = Buffer.from(savedFormParam).toString('base64');//savedForm is saved as attachment 
     let saveData = JSON.parse(savedFormParam)["data"];// This is the data part of the savedJson  
+
+
+    /**
+     * Apply Kiln Version
+     * Kiln V1 uses data: { items: []}
+     * Kiln V2 uses dataSources []
+     */
+    const kilnVersion = Object.keys(JSON.parse(savedFormParam)["data"]).includes("items") ? 1 : 2;
     const formDefinitionItems = kilnVersion === 1 ? JSON.parse(savedFormParam)["form_definition"]["data"]["items"] : JSON.parse(savedFormParam)["form_definition"]["elements"];// This is the field info for form items
     
     // dateItemsId : This will contain all of the IDs of the date fields
@@ -300,7 +302,7 @@ async function loadICMdata(req, res) {
         response = await axios.get(url, { params: query, headers });
         let return_data = Buffer.from(response.data["Doc Attachment Id"], 'base64').toString('utf-8');
         //validate the returned data to be of the expected format 
-        const valid = isJsonStringValid(return_data, 1); //TODO ADO-3215 change for kiln version
+        const valid = isJsonStringValid(return_data);
         if (!valid) {
             console.log('JSON is  not valid ');
             return res

--- a/schema/form_definitionV2.yaml
+++ b/schema/form_definitionV2.yaml
@@ -1,0 +1,321 @@
+type: object
+required:
+  - id
+  - version
+  - ministry_id
+  - data
+properties:
+  version:
+    anyOf:
+      - type: string
+      - type: number
+  ministry_id:
+    anyOf:
+      - type: string
+      - type: number
+  id:
+    type: string
+  lastModified:
+    type: string
+  title:
+    type: string
+  readOnly:
+    type: boolean
+  form_id:
+    type: string
+  deployed_to:
+    anyOf:
+      - type: string
+      - type: "null"
+  dataSources:
+    type: array
+    items:
+      type: object
+    default: []
+  data:
+    type: object
+    properties:
+      form_id:
+        type: number
+      form_developer:
+        type: object
+      comments: 
+        type: "null"
+      created_at: 
+        type: string
+      updated_at: 
+        type: string
+  interface:
+    type: array
+  styles:
+    type: array
+  scripts:
+    type: array
+  elements: 
+    type: array
+    items:
+      type: object
+      properties:
+        fields:
+          type: array
+          items:
+            $ref: "#/definitions/Item"
+
+definitions:
+  Item:
+    required:
+      - uuid
+      - type
+    type: object
+    properties:
+      type:
+        type: string
+      name: 
+        type: string
+      description: 
+        anyOf:
+          - type: string
+          - type: "null"
+      help_text:
+          anyOf:
+          - type: string
+          - type: "null"
+      is_required:
+        type: boolean
+      visible_web:
+        type: boolean
+      visible_pdf:
+        type: boolean
+      custom_visibility:
+        anyOf:
+          - type: string
+          - type: "null"
+      is_read_only:
+        type: boolean
+      save_on_submit:
+        type: boolean
+      order:
+        type: number
+      options:
+        type: array
+      parent_id:
+        anyOf:
+          - type: number
+          - type: "null"
+      attributes:
+        type: array
+        items:
+          type: object
+          properties:
+            hideLabel:
+              type: boolean
+            defaultChecked:
+              type: boolean
+            deletedAt: 
+                anyOf:
+                - type: string
+                - type: "null"
+            text:
+              type: string
+            kind: 
+              type: string
+            placeholder:
+              type: string
+            minDate:
+              type: string
+            maxDate: 
+              type: string
+            dateFormat: 
+              type: string
+            formatStyle:
+              type: string
+            max:
+              type: string
+            min:
+              type: string
+            step:
+              type: string
+            value:
+              type: string
+      label:
+        anyOf:
+          - type: string
+          - type: "null"
+      placeholder:
+        anyOf:
+          - type: string
+          - type: "null"
+      id:
+        type: string
+      mask:
+        anyOf:
+          - type: string
+          - type: "null"
+      codeContext:
+        type: object
+        properties:
+          name:
+            type: string
+      header:
+        type: string
+      offText:
+        type: string
+      onText:
+        type: string
+      size:
+        type: string
+      listItems:
+        type: array
+        items:
+          type: object
+          properties:
+            value:
+              type: string
+            text:
+              type: string
+          required:
+            - text
+            - value
+      groupItems:
+        type: array
+        items:
+          type: object
+          properties:
+            fields:
+              type: array
+              items:
+                $ref: "#/definitions/Item"
+      repeater:
+        type: boolean
+      helperText:
+        anyOf:
+          - type: string
+          - type: "null"
+      value:
+        anyOf:
+          - type: string
+          - type: "null"
+      filenameStatus:
+        type: string
+      labelDescription:
+        type: string
+      initialRows:
+        type: string
+      initialColumns:
+        type: string
+      initialHeaderNames:
+        type: string
+      repeaterItemLabel:
+        type: string
+      validation:
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - required
+                - pattern
+                - minLength
+                - maxLength
+                - minDate
+                - maxDate
+                - minValue
+                - maxValue
+                - javascript
+            value:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+            errorMessage:
+              anyOf:
+                - type: string
+                - type: "null"
+          required:
+            - type
+            - value
+            - errorMessage
+      conditions:
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - visibility
+                - readOnly
+                - calculatedValue
+                - saveOnSubmit
+            value:
+              type: string
+          required:
+            - type
+            - value
+          additionalProperties: false
+      webStyles:
+        anyOf:
+          - type: "null"
+          - type: object
+            additionalProperties:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+                - type: object
+                - type: array
+                - type: "null"
+      pdfStyles:
+        anyOf:
+          - type: "null"
+          - type: object
+            additionalProperties:
+              anyOf:
+                - type: string
+                - type: number
+                - type: boolean
+                - type: object
+                - type: array
+                - type: "null"
+      databindings:
+        oneOf:
+          - type: array
+            items:
+              type: object
+              properties:
+                path:
+                  type: string
+                source:
+                  type: string
+                order:
+                  type: number
+                condition:
+                  anyOf:
+                    - type: string
+                    - type: "null"
+              required:
+                - path
+                - source
+              additionalProperties: false
+          - type: object
+            properties:
+              path:
+                type: string
+              source:
+                type: string
+              order:
+                type: number
+              condition:
+                anyOf:
+                  - type: string
+                  - type: "null"
+            required:
+              - path
+              - source
+            additionalProperties: false
+      containerItems:
+        type: array
+        items:
+          $ref: "#/definitions/Item"       

--- a/validate.js
+++ b/validate.js
@@ -10,7 +10,14 @@ function loadSchema(schemaPath) {
 }
 
 // Function to validate JSON data against a YAML schema
-function validateJson(jsonData, kilnVersion) {
+function validateJson(jsonData) {
+
+    /**
+     * Apply Kiln Version
+     * Kiln V1 uses data: { items: []}
+     * Kiln V2 uses dataSources []
+     */
+    const kilnVersion = Object.keys(jsonData["data"]).includes("items") ? 1 : 2; 
     const schema = loadSchema("schema/saved_json.yaml");
     const formDefinitionSchema = kilnVersion === 1 ? loadSchema("schema/form_definition.yaml") : loadSchema("schema/form_definitionV2.yaml");
 
@@ -26,10 +33,10 @@ function validateJson(jsonData, kilnVersion) {
     return { valid, errors: validate.errors };
 }
 
-function isJsonStringValid(jsonDataString, kilnVersion) {
+function isJsonStringValid(jsonDataString) {
     try {
         const jsonData = JSON.parse(jsonDataString);  
-        return isJsonValid(jsonData, kilnVersion)
+        return isJsonValid(jsonData)
       }
       catch (error) {
         console.error("Error converting incoming json:", error);  
@@ -37,11 +44,11 @@ function isJsonStringValid(jsonDataString, kilnVersion) {
       }      
 }
 
-function isJsonValid(jsonData, kilnVersion) {
+function isJsonValid(jsonData) {
     try {
             //const jsonData = JSON.parse(jsonDataString);  
             if(jsonData) {        
-                const { valid, errors } = validateJson(jsonData, kilnVersion);  
+                const { valid, errors } = validateJson(jsonData);  
                 if (valid) {
                 console.log('JSON is valid ✅');
                 } else {

--- a/validate.js
+++ b/validate.js
@@ -10,9 +10,9 @@ function loadSchema(schemaPath) {
 }
 
 // Function to validate JSON data against a YAML schema
-function validateJson(jsonData) {
+function validateJson(jsonData, kilnVersion) {
     const schema = loadSchema("schema/saved_json.yaml");
-    const formDefinitionSchema = loadSchema("schema/form_definition.yaml");
+    const formDefinitionSchema = kilnVersion === 1 ? loadSchema("schema/form_definition.yaml") : loadSchema("schema/form_definitionV2.yaml");
 
     const ajv = new Ajv({ allErrors: true });
     addFormats(ajv);
@@ -26,10 +26,10 @@ function validateJson(jsonData) {
     return { valid, errors: validate.errors };
 }
 
-function isJsonStringValid(jsonDataString) {
+function isJsonStringValid(jsonDataString, kilnVersion) {
     try {
         const jsonData = JSON.parse(jsonDataString);  
-        return isJsonValid(jsonData)
+        return isJsonValid(jsonData, kilnVersion)
       }
       catch (error) {
         console.error("Error converting incoming json:", error);  
@@ -37,11 +37,11 @@ function isJsonStringValid(jsonDataString) {
       }      
 }
 
-function isJsonValid(jsonData) {
+function isJsonValid(jsonData, kilnVersion) {
     try {
             //const jsonData = JSON.parse(jsonDataString);  
             if(jsonData) {        
-                const { valid, errors } = validateJson(jsonData);  
+                const { valid, errors } = validateJson(jsonData, kilnVersion);  
                 if (valid) {
                 console.log('JSON is valid ✅');
                 } else {


### PR DESCRIPTION
## What changes did you make?

- Created form_definitionV2.yaml to use for validating JSONs sent by Kiln V2.
- Updated JSON validation across save ICM data, load ICM data, and generate PDF to recognize the differences between Kiln v1 and v2 data input so it would proceed to validate accordingly.
- Updated the XML generation to make note of Kiln v2 jsons and pull data from appropriate property
- Update the XML generation in save ICM data to shorten UUIDs for children/grouped values.

## Why did you make these changes?

- The JSON layouts used for kiln v1 and kiln v2 are different. Kiln-v2 jsons would not pass validation for functions because it uses "elements" rather than "data": "items" that kiln v1 uses to display information. A new yaml was needed for validating this different json layout.
- XML takes values from "data": "items", so having it determine if kiln v1 or v2 is required a check in save ICM data outside of the validate functions. Additionally, the kiln-v1 json uses a different property naming layout for children/grouped items than kiln-v2. The check for version is used for solving what naming changes the XML will use when it preps to generate.

## What alternatives did you consider?

Because there weren't many changes originally for the XML fixes, I was originally going to keep the kiln version identification to validation. However, it made more sense for save ICM data function to include the kiln version identifier to make future changes easier. 
Additionally, I had thought about inputting the kiln version into the validation functions rather than in the lowest validate function required. I went with keeping it in the function rather than being passed into the function so that there is less of an issue for any future versioning updates and no longer requires other code locations to recognize the kiln version and pass it along.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
