### PR TITLE
Update to dictionary values 1

### DIFF
--- a/dictionary/jsonXmlConversion.js
+++ b/dictionary/jsonXmlConversion.js
@@ -8,8 +8,53 @@
  * Property: version : a string that will check if the exception list should include the version of the form submitted. All values in version should overwrite the default form properties.
  */
 const formExceptions = {
-    "HR3689E": { 
-        "rootName": "ListOfDtFormInstanceLW", 
+    "CF0630": {
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "CF0631": {
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "CF0632": {
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "CF0633": {
+        "rootName": "ListOfDtFormInstanceLw", 
         "subRoots": ["FormInstance"],
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
@@ -24,7 +69,7 @@ const formExceptions = {
         }
     },
     "CF0925": {
-        "rootName": "", 
+        "rootName": "form1", 
         "subRoots": [],
         "wrapperTags": [
             {
@@ -99,7 +144,127 @@ const formExceptions = {
                 "omitFields": []
             }
         }
-    } 
+    },
+    "CF0926": {
+        "rootName": "form1", 
+        "subRoots": [],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "CF2900": {
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": [],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "HR0080": {
+        "rootName": "Results", 
+        "subRoots": [],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "HR3687E": {
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "HR3688E": {
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "HR3689E": { 
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "HR3690E": { 
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    },
+    "HR3704E": {
+        "rootName": "ListOfDtFormInstanceLw", 
+        "subRoots": ["FormInstance"],
+        "wrapperTags": [],
+        "allowCheckboxWithNoChange": [],
+        "omitFields": [],
+        "versions": {
+            "1": {
+                "omitFields": []
+            },
+            "2": {
+                "omitFields": []
+            }
+        }
+    }
 };
 
 module.exports = { formExceptions };


### PR DESCRIPTION
## What changes did you make?

Added form ids to the dictionary. Roots and sub-roots have been updated based on the spreadsheet: https://bcgov.sharepoint.com/:x:/r/teams/04071/_layouts/15/Doc.aspx?sourcedoc=%7B102B5DBB-6099-467D-8B2C-05AB55E35D5D%7D&file=Forms%20Top-level%20XML%20Hierarchy.xlsx&action=default&mobileredirect=true

Also updated the keys so that the form ids are in alphabetical order

## Why did you make these changes?

Roots and sub-roots for XML need to be changed/added for several forms. By adding these ids to the dictionary, it's possible to do the update.


### Checklist

- [X] **I have assigned at least one reviewer**

