### PR TITLE
(ADO-3390) addFields applied to dictionary and XML

### DIFF
--- a/dictionary/jsonXmlConversion.js
+++ b/dictionary/jsonXmlConversion.js
@@ -14,6 +14,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -29,6 +30,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -44,6 +46,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -59,6 +62,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -136,6 +140,7 @@ const formExceptions = {
         ],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions" : {
             "1" :{
                 "omitFields": []
@@ -151,6 +156,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -163,9 +169,154 @@ const formExceptions = {
     "CF2900": {
         "rootName": "ListOfDtFormInstanceLw", 
         "subRoots": [],
-        "wrapperTags": [],
+        "wrapperTags": [
+            {
+                "ListofDependent": {
+                    "Dependent": {
+                        "CareArrangementsList": {
+                            "CareArrangements": {
+                                "licensed-group-b650d0a6-2871-433c-9a2b-9e80a2f7c9a8": 4,
+                                "mailing-address-1-003b31e6-6661-4229-b17e-1d1121bb4de0": 4,
+                                "citytown-b8a078b2-4985-4cc6-9de4-48674704cd75": 4,
+                                "postal-code-7cf09061-3472-4a74-802f-76aa8c115aa0": 4,
+                                "comments-4532571d-f24a-4877-bf9e-d69f979b2a08": 4
+                            }
+                        },
+                        "first-name-4f1d33c2-cd25-4801-9902-d1d33a0ba010": 2,
+                        "middle-name-9db65275-66a0-4f3d-856b-9cd9ded0f385": 2,
+                        "last-name-dc75eb1e-d57d-4383-a9e6-5e0a86513700": 2,
+                        "date-of-birth-yyyy-mmm-dd-0e756b1c-47c9-482b-82fa-9c681c87ea55": 2,
+                        "radiobuttonlist-d7ada287-f4af-4a1a-ad9f-daa893b8789f": 2,
+                        "radiobuttonlist-bdbd4d0f-daf0-445e-abb0-4eb42f3e15c0": 2,
+                        "licensed-group-b650d0a6-2871-433c-9a2b-9e80a2f7c9a8": 2,
+                        "licensed-family-f14e4cd1-204e-41a7-b1b2-d7b910cc2ee4": 2,
+                        "licensed-preschool-program-15821c42-4a1f-4fc4-98e0-6a0fedc6cf91": 2,
+                        "registered-licence-not-required-455d1970-fe3a-4d7c-9ca0-d365f1177fb1": 2,
+                        "licence-not-required-a0b0868e-c7e0-43d3-b688-d2569108c595": 2,
+                        "in-childs-home-2b8a7f32-e472-4cad-aba5-254b33125844": 2,
+                        "radiobuttonlist-28b592b7-aba8-46dc-8caf-815b8684fd31": 2,
+                        "custody-details-e38e1e1a-4db9-460d-bde3-a9b626419173": 2
+                    }
+                }
+            },
+            {
+                "ListReasonForCare": {
+                    "ReasonForCare": {
+                        "name-of-employers-school-training-program-or-dates-looking-for-work-3bb24589-196e-4a3b-bf9d-0b2616efec89": 2,
+                        "start-date-yyyy-mmm-dd-a745b70e-8304-4814-be69-1b232c44beeb": 2,
+                        "end-date-yyyy-mmm-dd-d2df073a-101d-4a68-bf42-1a040ebf7585": 2,
+                        "week-days-andor-week-ends-317392fa-4395-401a-b9ec-fd60930177f1": 2,
+                        "week-end-days-per-week-8baf2547-c051-4fc5-849a-5aa527fb326a": 2,
+                        "week-end-hours-per-day-3afabfee-a210-4465-80e3-788bae3d59d4": 2,
+                        "week-day-days-per-week-3176c7d7-751b-4753-871c-d53bf6128e3e": 2,
+                        "week-day-hours-per-day-00303def-6fad-49d6-b72b-183abef2fbd5": 2,
+                        "regular-schedule-73687eed-2e55-4aa7-821a-deab607da5d3": 2,
+                        "start-time-0187c5ad-c8b0-420b-bded-595d2ecad5bd": 2,
+                        "end-time-d7f384c0-f80f-4aa3-9430-7a86187897df": 2,
+                        "additional-information-or-attach-a-schedule-77a4d493-0468-40a7-8d0e-af9ab9906085": 2,
+                        "travel-time-c1ab5674-a91d-4ab2-b096-213b07bdb69d": 2
+                    }
+                }
+            }
+        ],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {
+            "ICMApplicantDateofBirth": null,
+            "ApplicantGender": null,
+            "ApplicantPrimaryPhoneNumberType": null,
+            "ApplicantHomeApartment": null,
+            "ApplicantHomeMAKID": null,
+            "ApplicantMailingApartment": null,
+            "ApplicantEmail": null,
+            "CareArrangementUploaded": null,
+            "ICMSpouseDateofBirth": null,
+            "SpouseGender": null,
+            "ListofDependent": {
+                "Dependent": {
+                    "CareArrangementsList": {
+                        "CareArrangements": {
+                            "FacilityID": null,
+                            "CCAProviderName": null,
+                            "CCAProviderDaytimePhone": null,
+                            "CCAProviderSecondaryPhone": null,
+                            "FacilityName": null,
+                            "ServiceAddress": null,
+                            "ServiceCity": null,
+                            "ServicePostalCode": null,
+                            "CCACareType": null,
+                            "SundayFlag": null,
+                            "SaturdayFlag": null,
+                            "CCASupplierNumber": null,
+                            "CCAStartDate": null,
+                            "CCAEndDate": null,
+                            "MonthlyFee": null,
+                            "DailyFee": null,
+                            "SchoolClosureFee": null,
+                            "EnrolledYN": null,
+                            "SummerFlag": null,
+                            "CCAChildRelatedFlag": null,
+                            "CCAChildHomeFlag": null,
+                            "CCARelativeFlag": null,
+                            "CCARelationship": null,
+                            "CCASameHomeFlag": null,
+                            "CCAParentComments": null,
+                            "ParentSumissionDate": null,
+                            "ProviderSubmissionDate": null,
+                            "ProviderBCeID": null,
+                            "MondayFlag": null,
+                            "MondayTime1Start": null,
+                            "MondayTime1End": null,
+                            "TuesdayFlag": null,
+                            "TuesdayStart1Time": null,
+                            "TuesdayEnd1Time": null,
+                            "WednesdayFlag": null,
+                            "WednesdayStart1Time": null,
+                            "WednesdayEnd1Time": null,
+                            "ThursdayFlag": null,
+                            "ThursdayStart1Time": null,
+                            "ThursdayEnd1Time": null,
+                            "FridayFlag": null,
+                            "FridayStart1Time": null,
+                            "FridayEnd1Time": null,
+                            "ProviderOrLicenseeName": null,
+                            "FirstTimeApplyingFlag": null,
+                            "ReplacingProviderFlag": null,
+                            "ReplacingProviderName": null,
+                            "AdditionalProviderFlag": null,
+                            "OtherProviderName": null
+                        }
+                    },
+                    "ICMDependantDateofBirth": null,
+                    "DependantGender": null,
+                    "DependantMinistryPlacement": null,
+                    "ICMDependentCount": null
+                }
+            },
+            "ListofIncome": {
+                "AdditionalIncomeReported": null
+            },
+            "ListReasonForCare": {
+                "ReasonForCare": {
+                    "Role": null,
+                    "CareType": null,
+                    "ICMTravelTime": null,
+                    "ICMStartDate": null,
+                    "ICMCareType": null
+                }
+            },
+            "ICMBCFlag": null,
+            "ICMFerderalFlagSpouse": null,
+            "ICMFederalFlag": null,
+            "Field1": null,
+            "ICMSpouseGUID": null,
+            "CareArrangementExists": null,
+            "CareArrangementDetailsPresent": null,
+            "CRAFiled": null,
+            "IncomeSameSinceTaxFiling": null,
+            "SpouseCRAFiled": null,
+            "SpouseIncomeSameSinceTaxFiling": null
+        },
         "versions": {
             "1": {
                 "omitFields": []
@@ -181,6 +332,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -196,6 +348,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -211,6 +364,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -226,6 +380,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -241,6 +396,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []
@@ -256,6 +412,7 @@ const formExceptions = {
         "wrapperTags": [],
         "allowCheckboxWithNoChange": [],
         "omitFields": [],
+        "addFields": {},
         "versions": {
             "1": {
                 "omitFields": []

--- a/saveICMdataHandler.js
+++ b/saveICMdataHandler.js
@@ -166,6 +166,8 @@ async function saveICMdata(req, res) {
     let toWrapIds = {}; //List of ids that will need to be placed in a wrapper. This only happens if form exception is true and wrapperTags exists
     const noCheckboxChange = (isFormException && propertyExists(dictionary, formId, "allowCheckboxWithNoChange")) ? dictionary[formId].allowCheckboxWithNoChange : [];
     const omitFields = (isFormException && propertyExists(dictionary, formId, "omitFields")) ? dictionary[formId].omitFields : [];
+    const addFields = (isFormException && propertyExists(dictionary, formId, "addFields")) ? dictionary[formId].addFields : {};
+
     if (isFormException && propertyExists(dictionary, formId, "wrapperTags")) { 
         dictionary[formId]["wrapperTags"].forEach((wrapperTag, index) => {
             const tagKey = Object.keys(dictionary[formId]["wrapperTags"][index])[0];
@@ -176,7 +178,7 @@ async function saveICMdata(req, res) {
     }
 
     // The updated JSON values required for XML creation
-    const truncatedKeysSaveData = fixJSONValuesForXML(saveData, {}, toWrapIds, dateItemsId, checkboxItemsId, noCheckboxChange, omitFields);
+    const truncatedKeysSaveData = fixJSONValuesForXML(saveData, {}, toWrapIds, dateItemsId, checkboxItemsId, noCheckboxChange, omitFields, addFields, kilnVersion);
     
     let builder; // This will be for building the XML
     if (isFormException) { // If any forms with the correct version (TODO) have been listed as exceptions, then proceed with their form exceptions
@@ -553,11 +555,12 @@ function multilevelWrappers(truncatedKeysSaveData, toWrapIds, dataToWrap, oldKey
  * @param checkboxItemsId : list of checkbox fields
  * @param noCheckboxChange : list of checkbox UUIDs that should not have their value changed
  * @param omitFields : list of field UUIDS that should not be included in the XML
+ * @param addFields : list of empty fields to add for form to succeed in saving as XML
  * @param {number} kilnVersion : the Kiln version matching the save data json layout
  * @returns truncatedKeysSaveData : a list of key-object pairs
  */
 
-function fixJSONValuesForXML (saveData, truncatedKeysSaveData, toWrapIds, dateItemsId, checkboxItemsId, noCheckboxChange, omitFields, kilnVersion) {
+function fixJSONValuesForXML (saveData, truncatedKeysSaveData, toWrapIds, dateItemsId, checkboxItemsId, noCheckboxChange, omitFields, addFields, kilnVersion) {
     for(let oldKey in saveData) { //This begins trunicating the JSON keys for XML (UUID should be first 8 characters)
         if (!omitFields.includes(oldKey)) {
             const stringLength = oldKey.length;
@@ -652,6 +655,120 @@ function fixJSONValuesForXML (saveData, truncatedKeysSaveData, toWrapIds, dateIt
                 }
             }
         }
+    }
+    //Check additional fields needed before returning final value
+    const additionalFieldKeys = Object.keys(addFields);
+    if (additionalFieldKeys.length > 0) {
+        additionalFieldKeys.forEach(key => {
+            if (addFields[key] === null) { //Parent key/field. If it passes, then this should not exist in form already because this is for ADDING fields. If it exists in form, it will be overwritten.
+                truncatedKeysSaveData[key] = null;
+            } else if (truncatedKeysSaveData[key] === undefined) { //If truncatedKeysSaveData[key] does not exist, create it with all values under the add key from dictionary
+                truncatedKeysSaveData[key] = addFields[key];
+            } else { //Has children in dictionary AND truncatedKeysSaveData exists already
+
+                    //Consider making the following a recursive function in a future iteration
+                    /**
+                     * For each key:
+                     *  Check to see if field is undefined. If undefined, then define it as empty
+                     *  Get the keys of the object if avaliable. Otherwise, get empty array
+                     *  If truncatedKeysSaveData keys lead to a group/list: apply values from dictionary
+                     *  Else if there are child keys avaliable: check the child keys (i.e. repeat this for each key)
+                     *  Else: save current level truncatedKeysSaveData with the current dictionary key values
+                     */
+
+                const childFields1 = addFields[key] != null ? Object.keys(addFields[key]) : [];
+                 if (truncatedKeysSaveData[key] && truncatedKeysSaveData[key].length != undefined) {
+                    truncatedKeysSaveData[key][childKey1].forEach((value, index) => {
+                        truncatedKeysSaveData[key][index] = {...truncatedKeysSaveData[key][index], ...addFields[key]};
+                    });
+                } else if(childFields1.length > 0) {
+                    childFields1.forEach(childKey1 => {
+                        if (truncatedKeysSaveData[key][childKey1] === undefined) {
+                            truncatedKeysSaveData[key][childKey1] = {};
+                        }
+                        const childFields2 = addFields[key][childKey1] != null ? Object.keys(addFields[key][childKey1]) : [];
+                        if (truncatedKeysSaveData[key][childKey1] && truncatedKeysSaveData[key][childKey1].length != undefined) { //Add the second layer of empty fields to groups
+                            truncatedKeysSaveData[key][childKey1].forEach((value, index) => {
+                                truncatedKeysSaveData[key][childKey1][index] = {...truncatedKeysSaveData[key][childKey1][index], ...addFields[key][childKey1]};
+                            });
+                        } else if (childFields2.length > 0) { //Continue if there are more fields listed
+                            childFields2.forEach(childKey2 => {
+                                if (truncatedKeysSaveData[key][childKey1][childKey2] === undefined) {
+                                    truncatedKeysSaveData[key][childKey1][childKey2] = {};
+                                }
+                                const childFields3 = addFields[key][childKey1][childKey2] != null ? Object.keys(addFields[key][childKey1][childKey2]) : [];
+                                if (truncatedKeysSaveData[key][childKey1][childKey2] && truncatedKeysSaveData[key][childKey1][childKey2].length != undefined) {
+                                    truncatedKeysSaveData[key][childKey1][childKey2].forEach((value, index) => {
+                                        truncatedKeysSaveData[key][childKey1][childKey2][index] = {...truncatedKeysSaveData[key][childKey1][childKey2][index], ...addFields[key][childKey1][childKey2]};
+                                    });
+                                } else if (childFields3.length > 0) {
+                                    childFields3.forEach(childKey3 => {
+                                        if (truncatedKeysSaveData[key][childKey1][childKey2][childKey3] === undefined) {
+                                            truncatedKeysSaveData[key][childKey1][childKey2][childKey3] = {};
+                                        }
+                                        const childFields4 = addFields[key][childKey1][childKey2][childKey3] != null ? Object.keys(addFields[key][childKey1][childKey2][childKey3]) : [];
+                                        if (truncatedKeysSaveData[key][childKey1][childKey2][childKey3] && truncatedKeysSaveData[key][childKey1][childKey2][childKey3].length != undefined) {
+                                            truncatedKeysSaveData[key][childKey1][childKey2][childKey3].forEach((value, index) => {
+                                                truncatedKeysSaveData[key][childKey1][childKey2][childKey3][index] = {...truncatedKeysSaveData[key][childKey1][childKey2][childKey3][index], ...addFields[key][childKey1][childKey2][childKey3]};
+                                            });
+                                        } else if (childFields4.length > 0) {
+                                            childFields4.forEach(childKey4 => {
+                                                if (truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4] === undefined) {
+                                                    truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4] = {};
+                                                }
+                                                const childFields5 = addFields[key][childKey1][childKey2][childKey3][childKey4] != null ? Object.keys(addFields[key][childKey1][childKey2][childKey3][childKey4]) : [];
+                                                if (truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4] && truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4].length != undefined) {
+                                                    truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4].forEach((value, index) => {
+                                                        truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][index] = {...truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][index], ...addFields[key][childKey1][childKey2][childKey3][childKey4]};
+                                                    });
+                                                } else if (childFields5.length > 0) {
+                                                    childFields5.forEach(childKey5 => {
+                                                        if (truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5] === undefined) {
+                                                            truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5] = {};
+                                                        }
+                                                        const childFields6 = addFields[key][childKey1][childKey2][childKey3][childKey4][childKey5] != null ? Object.keys(addFields[key][childKey1][childKey2][childKey3][childKey4][childKey5]) : [];
+                                                        if (truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5] && truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5].length != undefined) {
+                                                            truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5].forEach((value, index) => {
+                                                                truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][index] = {...truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][index], ...addFields[key][childKey1][childKey2][childKey3][childKey4][childKey5]};
+                                                            });
+                                                        } else if (childFields6.length > 0) {
+                                                            childFields6.forEach(childKey6 => {
+                                                                if (truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6] === undefined) {
+                                                                    truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6] = {};
+                                                                }
+                                                                if (truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6] && truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6].length != undefined) {
+                                                                    truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5].forEach((value, index) => {
+                                                                        truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6][index] = {...truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6][index], ...addFields[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6]};
+                                                                    });
+                                                                } else {
+                                                                    truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6] = addFields[key][childKey1][childKey2][childKey3][childKey4][childKey5][childKey6];
+                                                                }
+                                                            });
+                                                        } else {
+                                                            truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4][childKey5] = addFields[key][childKey1][childKey2][childKey3][childKey4][childKey5];
+                                                        }
+                                                    });
+                                                } else {
+                                                    truncatedKeysSaveData[key][childKey1][childKey2][childKey3][childKey4] = addFields[key][childKey1][childKey2][childKey3][childKey4];
+                                                }
+                                            });
+                                        } else {
+                                            truncatedKeysSaveData[key][childKey1][childKey2][childKey3] = addFields[key][childKey1][childKey2][childKey3];
+                                        }
+                                    });
+                                } else {
+                                    truncatedKeysSaveData[key][childKey1][childKey2] = addFields[key][childKey1][childKey2];
+                                }
+                            });
+                        } else { //If value is null or if truncatedKeysSaveData[key][childKey1] did not exist
+                            truncatedKeysSaveData[key][childKey1] = addFields[key][childKey1];
+                        }
+                    });
+                } else { //The parent key has not been made yet, so make it and add dictionary values. This is just a precaution because the scenario should be solved during addFields null check
+                    truncatedKeysSaveData[key] = addFields[key];
+                }
+            }
+        });
     }
     return truncatedKeysSaveData;
 }


### PR DESCRIPTION
## What changes did you make?

Dictionary now supports addFields. This means empty fields can now be added to the JSON in order to appear in the XML after conversion.

Fix where Kiln version was only giving results in XML for V2 instead of both v1 and v2.

CF2900 has wrapper tags and add fields applied to it in dictionary.

## Why did you make these changes?

Some forms require the XML to include empty field tags. In order to do this, the JSON needs to have required key-value pairs as "field name": null. This update fulfils this requirement for up to 6 levels deep into an object's key-value pairs.

CF2900 was done to assist with testing the XML.

## What alternatives did you consider?

The solution for this has the potential to work as a recursive function. It remains up to 6-levels rather than be made recursive in order to start testing for additional values.

NOTE: licensed-group-b650d0a6-2871-433c-9a2b-9e80a2f7c9a8 appears twice in CF2900 wrapper tags. It will display as the second one in XML (i.e. the key-pair with value 2).

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
