### PR TITLE
Updated image tag reference for Docker

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,7 +17,10 @@ jobs:
 
   build_and_push:
     runs-on: ubuntu-latest
-
+    
+    outputs:
+      image_tag: ${{ steps.branch_tag.outputs.image_tag }}
+    
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -51,9 +54,6 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.branch_tag.outputs.image_tag }}
           labels: ${{ steps.meta.outputs.labels }}
-
-    outputs:
-      image_tag: ${{ steps.branch_tag.outputs.image_tag }}
 
   deploy:
     needs: build_and_push

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: bcgov/communication-layer
 
 jobs:
 
@@ -38,7 +38,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,ref=${{ github.ref_name }}
+            type=ref,event=branch
       
       - name: Set branch tag for image
         id: branch_tag


### PR DESCRIPTION
## What changes did you make?

Updated image tag reference for Docker to use lowercase reference of this repository name.

## Why did you make these changes?

The current "Build and push Docker image" step in Github Actions is failing due to this error:
invalid tag "ghcr.io/bcgov/Communication-Layer:dev": repository name must be lowercase

This PR will address this issue.

## What alternatives did you consider?

None.

### Checklist

- [X] **I have assigned at least one reviewer**
- [ ] **My code meets the style guide**
- [ ] **My code has adequate test coverage (if applicable)**
